### PR TITLE
Fix: Ensure hero title remains visible after animation

### DIFF
--- a/cybersecurity-company/src/app/home/home.css
+++ b/cybersecurity-company/src/app/home/home.css
@@ -57,6 +57,7 @@ mat-toolbar a:hover {
   margin-bottom: 24px;
   text-shadow: none;
   animation: slideInFromTop 1s ease-out;
+  animation-fill-mode: forwards; /* Keep the state of the last keyframe */
 }
 
 @keyframes slideInFromTop {


### PR DESCRIPTION
Added `animation-fill-mode: forwards;` to the .hero h1 CSS rule to prevent the title from disappearing after its entrance animation completes.