### PR TITLE
feat: Implement PDF file upload functionality for LLM chat

### DIFF
--- a/cybersecurity-company/src/app/chat/chat.css
+++ b/cybersecurity-company/src/app/chat/chat.css
@@ -232,27 +232,97 @@
 /* Chat Input */
 .chat-input {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-end; /* Align items to the bottom */
   gap: 12px;
   padding: 16px;
   background: #fafafa;
   border-top: 1px solid #e0e0e0;
   border-radius: 0 0 12px 12px;
+  position: relative; /* For positioning the selected file chip */
 }
 
 .message-field {
   flex: 1;
 }
 
+.attachment-button {
+  margin-bottom: 4px; /* Align with FAB send button */
+}
+
 .send-button {
   width: 56px;
   height: 56px;
-  margin-bottom: 4px;
+  margin-bottom: 4px; /* Align with text area bottom */
 }
 
 .send-button[disabled] {
   opacity: 0.5;
 }
+
+/* Selected file chip styles (below input area) */
+.selected-file-chip {
+  display: flex;
+  align-items: center;
+  padding: 6px 10px; /* Slightly smaller padding */
+  background-color: #e8eaf6; /* Indigo lighten-5 */
+  color: #3f51b5; /* Indigo */
+  border: 1px solid #c5cae9; /* Indigo lighten-4 */
+  border-radius: 16px;
+  margin-top: -8px; /* Pull it up slightly if chat-input has padding-bottom */
+  margin-bottom: 8px; /* Space before next element if any */
+  font-size: 0.8em;
+  width: fit-content; /* Only as wide as content */
+  max-width: 90%; /* Prevent overflow */
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.selected-file-chip mat-icon {
+  margin-right: 6px;
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+}
+
+.selected-file-chip span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.selected-file-chip button mat-icon {
+  font-size: 18px; /* Slightly larger for clarity */
+  width: 18px;
+  height: 18px;
+}
+
+
+/* Styling for file attachment chip within a message */
+.file-attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  background-color: #e0e0e0;
+  border-radius: 12px;
+  margin-bottom: 6px;
+  font-size: 0.85em;
+  border: 1px solid #ccc;
+  max-width: 100%;
+}
+
+.file-attachment-chip mat-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  margin-right: 6px;
+}
+
+.file-attachment-chip span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 
 /* Animations */
 @keyframes fadeIn {
@@ -297,10 +367,22 @@
   
   .chat-input {
     padding: 12px;
+    flex-wrap: wrap; /* Allow wrapping for selected file chip */
+  }
+
+  .message-field {
+    min-width: calc(100% - 120px); /* Adjust based on button sizes */
   }
   
   .send-button {
     width: 48px;
     height: 48px;
+  }
+
+  .selected-file-chip {
+    width: 100%; /* Full width on small screens */
+    margin-top: 8px; /* Add space when it wraps */
+    order: 3; /* Place it last in flex order */
+    justify-content: center;
   }
 }

--- a/cybersecurity-company/src/app/chat/chat.html
+++ b/cybersecurity-company/src/app/chat/chat.html
@@ -45,7 +45,15 @@
           </div>
           <div class="message-body">
             <!-- Render message content as Markdown -->
-            <div class="message-text" [innerHTML]="message.content | markdown"></div>
+            <div class="message-text">
+              <!-- Display file if present -->
+              <div *ngIf="isUserMessageWithFile(message)" class="file-attachment-chip">
+                <mat-icon>attach_file</mat-icon>
+                <span>{{ getUserMessageFilename(message) }}</span>
+              </div>
+              <!-- Display text part -->
+              <div [innerHTML]="getTextFromMessage(message) | markdown"></div>
+            </div>
             <div class="message-time">{{ formatTime(message.timestamp) }}</div>
             <div class="message-actions">
               <button mat-icon-button (click)="deleteMessage(i)" matTooltip="Delete message">
@@ -101,13 +109,29 @@
           cdkAutosizeMaxRows="4">
         </textarea>
       </mat-form-field>
+      <input type="file" #fileInput style="display: none" (change)="onFileSelected($event)" accept=".pdf"/>
+      <button
+        mat-icon-button
+        (click)="fileInput.click()"
+        [disabled]="isLoading"
+        matTooltip="Attach PDF file"
+        class="attachment-button">
+        <mat-icon>attachment</mat-icon>
+      </button>
       <button 
         mat-fab 
         color="primary" 
         (click)="sendMessage()" 
-        [disabled]="!currentMessage.trim() || isLoading"
+        [disabled]="(!currentMessage.trim() && !selectedFile) || isLoading"
         class="send-button">
         <mat-icon>send</mat-icon>
+      </button>
+    </div>
+    <div *ngIf="selectedFile" class="selected-file-chip">
+      <mat-icon>attach_file</mat-icon>
+      <span>{{ selectedFile.name }}</span>
+      <button mat-icon-button (click)="clearSelectedFile()" matTooltip="Remove file">
+        <mat-icon>close</mat-icon>
       </button>
     </div>
   </div>

--- a/cybersecurity-company/src/app/chat/chat.ts
+++ b/cybersecurity-company/src/app/chat/chat.ts
@@ -43,6 +43,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   chatSession: ChatSession | null = null;
   isLLMConfigured: boolean = false;
   errorMessage: string = '';
+  selectedFile: File | null = null;
 
   constructor(private llmSettingsService: LLMSettingsService) {}
 
@@ -69,7 +70,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   async sendMessage() {
-    if (!this.currentMessage.trim() || this.isLoading || !this.isLLMConfigured) {
+    if ((!this.currentMessage.trim() && !this.selectedFile) || this.isLoading || !this.isLLMConfigured) {
       return;
     }
 
@@ -77,13 +78,31 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.errorMessage = '';
     const message = this.currentMessage.trim();
     this.currentMessage = '';
+    const file = this.selectedFile;
+    this.selectedFile = null; // Clear selected file
+
+    // Convert file to base64 if present
+    let fileData: { name: string, content: string } | undefined;
+    if (file) {
+      try {
+        const base64Content = await this.readFileAsBase64(file);
+        fileData = { name: file.name, content: base64Content };
+      } catch (error) {
+        console.error('Error reading file:', error);
+        this.errorMessage = 'Error reading file. Please try again.';
+        this.isLoading = false;
+        return;
+      }
+    }
 
     // Begin sending the message but don't await immediately
-    const sendPromise = this.llmSettingsService.sendMessage(message);
+    const sendPromise = this.llmSettingsService.sendMessage(message, fileData);
 
     // Immediately refresh chat session so the user's message shows
+    // (The user message part of sendMessage in service already handles this)
     this.chatSession = this.llmSettingsService.getCurrentChatSession();
     setTimeout(() => this.scrollToBottom(), 100);
+
 
     try {
       await sendPromise;
@@ -102,6 +121,50 @@ export class ChatComponent implements OnInit, OnDestroy {
         }
       }, 100);
     }
+  }
+
+  private readFileAsBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        // result is DataURL (e.g., data:application/pdf;base64,xxxxx)
+        // We need to extract only the base64 part
+        const base64String = (reader.result as string).split(',')[1];
+        resolve(base64String);
+      };
+      reader.onerror = (error) => reject(error);
+      reader.readAsDataURL(file);
+    });
+  }
+
+  onFileSelected(event: Event): void {
+    const element = event.currentTarget as HTMLInputElement;
+    let fileList: FileList | null = element.files;
+    if (fileList && fileList.length > 0) {
+      const file = fileList[0];
+      // Basic validation (e.g., file type, size)
+      if (file.type !== 'application/pdf') {
+        this.errorMessage = 'Only PDF files are allowed.';
+        this.selectedFile = null;
+        element.value = ''; // Clear the input
+        return;
+      }
+      if (file.size > 32 * 1024 * 1024) { // 32MB limit (as per docs)
+        this.errorMessage = 'File size exceeds 32MB limit.';
+        this.selectedFile = null;
+        element.value = ''; // Clear the input
+        return;
+      }
+      this.selectedFile = file;
+      this.errorMessage = ''; // Clear any previous error
+    }
+  }
+
+  clearSelectedFile(): void {
+    this.selectedFile = null;
+    // Also reset the file input if you have a reference to it
+    // e.g., @ViewChild('fileInput') fileInputRef: ElementRef;
+    // if (this.fileInputRef) { this.fileInputRef.nativeElement.value = ''; }
   }
 
   onKeyPress(event: KeyboardEvent) {
@@ -173,5 +236,29 @@ export class ChatComponent implements OnInit, OnDestroy {
     if (this.isLLMConfigured && !this.chatSession) {
       this.loadChatSession();
     }
+  }
+
+  // Helper methods for rendering complex messages in the template
+  isUserMessageWithFile(message: ChatMessage): boolean {
+    if (message.role === 'user' && Array.isArray(message.content)) {
+      return message.content.some(part => part.type === 'file');
+    }
+    return false;
+  }
+
+  getUserMessageFilename(message: ChatMessage): string {
+    if (this.isUserMessageWithFile(message)) {
+      const filePart = (message.content as Array<any>).find(part => part.type === 'file');
+      return filePart?.file?.filename || 'Attached File';
+    }
+    return '';
+  }
+
+  getTextFromMessage(message: ChatMessage): string {
+    if (Array.isArray(message.content)) {
+      const textPart = message.content.find(part => part.type === 'text');
+      return textPart ? (textPart as any).text : '';
+    }
+    return message.content as string; // Fallback for simple string content (e.g., assistant messages)
   }
 }


### PR DESCRIPTION
This feature allows users to attach PDF files to their chat messages. The content of the PDF is base64 encoded and sent to the LLM API along with the text message.

Changes include:
- Modified chat.html to add an attachment button and file input.
- Updated chat.ts to handle file selection, base64 encoding, and display of selected files.
- Modified llm-settings.service.ts to update ChatMessage interface and API call structure to support file content.
- Added CSS for styling the attachment icon, selected file chip, and file chip within messages.
- Fixed a bug related to rendering user messages with attachments in the chat interface.